### PR TITLE
Refactor identifiers

### DIFF
--- a/src/js/components/admin/AdminApp.js
+++ b/src/js/components/admin/AdminApp.js
@@ -445,7 +445,7 @@ class AdminApp extends Component {
           const columnList = tableData.data.reduce((accumulator, table, tableIndex) => {
             const tableColumns = table.columns.map((tableColumn, columnIndex) => {
               return Object.assign({}, tableColumn, {
-                label: `Table #${tableIndex} Column #${columnIndex}`,
+                label: `Input table #${tableIndex} Column #${columnIndex}`,
                 value: {
                   tableIndex: tableIndex,
                   columnIndex: columnIndex

--- a/src/js/components/admin/AdminApp.js
+++ b/src/js/components/admin/AdminApp.js
@@ -262,23 +262,38 @@ class AdminApp extends Component {
   }
 
   addIdentifier(type) {
-    const { identifiers } = this.state
-
-    let metadataKey = ''
-    let value = ''
-    if (type === 'metadata' && this.state.status == 'create') {
-      metadataKey = Object.keys(this.state.tableData.metadata)[0]
-      value = this.state.tableData.metadata[metadataKey]
-    }
+    const { identifiers, tableData } = this.state
 
     const identifier = {
       type: type,
-      tableIndex: 0,
-      lineNumber: '',
-      metadataKey: metadataKey,
-      headerKey: '',
-      value: value,
-      isRegex: false
+      isRegex: false,
+      outputTableIndex: null,
+      outputLayer: '',
+      outputKey: ''
+    }
+
+    if (this.state.status == 'create') {
+      if (type === 'fileMetadata') {
+        identifier['key'] = Object.keys(tableData.metadata)[0]
+        identifier['value'] = tableData.metadata[identifier['key']]
+      }
+      if (type === 'tableMetadata') {
+        identifier['tableIndex'] = 0
+
+        if (tableData.tables.length > 0 && tableData.tables[0].metadata !== undefined) {
+          identifier['key'] = Object.keys(tableData.tables[0].metadata)[0]
+          identifier['value'] = tableData.tables[0].metadata[identifier['key']]
+        } else {
+          identifier['key'] = ''
+          identifier['value'] = ''
+        }
+
+      }
+      if (type === 'tableHeader') {
+        identifier['tableIndex'] = 0
+        identifier['lineNumber'] = ''
+        identifier['value'] = ''
+      }
     }
 
     identifiers.push(identifier)

--- a/src/js/components/admin/create/IdentifierForm.js
+++ b/src/js/components/admin/create/IdentifierForm.js
@@ -9,31 +9,29 @@ class IdentifierForm extends Component {
   }
 
   render() {
+    const { type, identifiers, tableData, tables, addIdentifier, updateIdentifier, removeIdentifier } = this.props
+
     return (
       <div className="mb-4">
         {
-          this.props.identifiers.map((identifier, index) => {
-            if (identifier.type === this.props.type) {
+          identifiers.map((identifier, index) => {
+            if (identifier.type === type) {
               return <IdentifierInput
                 key={index}
-                id={index}
-                type={identifier.type}
-                tableIndex={identifier.tableIndex}
-                lineNumber={identifier.lineNumber}
-                metadataKey={identifier.metadataKey}
-                headerKey={identifier.headerKey}
-                value={identifier.value}
-                isRegex={identifier.isRegex}
-                options={this.props.data}
-                removeIdentifier={this.props.removeIdentifier}
-                updateIdentifier={this.props.updateIdentifier}
+                index={index}
+                type={type}
+                identifier={identifier}
+                tableData={tableData}
+                tables={tables}
+                removeIdentifier={removeIdentifier}
+                updateIdentifier={updateIdentifier}
               />
             }
           })
         }
         <form>
             <div className="form">
-              <button type="button" className="btn btn-success btn-sm" onClick={event => this.props.addIdentifier(this.props.type)}>
+              <button type="button" className="btn btn-success btn-sm" onClick={event => addIdentifier(type)}>
                 Add Identifier
               </button>
             </div>

--- a/src/js/components/admin/create/ProfileCreate.js
+++ b/src/js/components/admin/create/ProfileCreate.js
@@ -194,26 +194,59 @@ class ProfileCreate extends Component {
             <div className="card rounded-0 mt-3">
               <div className="card-header">Identifiers</div>
               <div className="card-body">
-                <label>Based on metadata</label>
+                <label>Based on file metadata</label>
                 <IdentifierForm
-                  type="metadata"
+                  type="fileMetadata"
                   identifiers={identifiers}
+                  tableData={tableData}
+                  tables={tables}
                   addIdentifier={addIdentifier}
                   updateIdentifier={updateIdentifier}
                   removeIdentifier={removeIdentifier}
-                  data={tableData.metadata}
+                />
+
+                <label>Based on Table metadata</label>
+                <IdentifierForm
+                  type="tableMetadata"
+                  identifiers={identifiers}
+                  tableData={tableData}
+                  tables={tables}
+                  addIdentifier={addIdentifier}
+                  updateIdentifier={updateIdentifier}
+                  removeIdentifier={removeIdentifier}
                 />
 
                 <label>Based on table headers</label>
                 <IdentifierForm
-                  type="table"
+                  type="tableHeader"
                   identifiers={identifiers}
+                  tableData={tableData}
+                  tables={tables}
                   addIdentifier={addIdentifier}
                   updateIdentifier={updateIdentifier}
                   removeIdentifier={removeIdentifier}
-                  data={tableData.data}
                 />
-                <small className="text-muted">The identifiers you create will be used to find the right profile for uploaded files. The 'value' will be compared to the selected file metadata or to the header of a table. If you provide a line number, only this line of the header will be used. If you select 'RexExp', you can enter a regular expression as value, which will be used to match the file. If you fill in the field 'header key', the compared string (or the first group of a given RegExp) will be added to the header of the converted file.</small>
+                <small>
+                  <p className="text-muted">
+                    The identifiers you create here are used to find the correct profile for uploaded files, and they are used to extract metadata and add it to the output tables.
+                  </p>
+                  <ul className="text-muted mb-0">
+                    <li>
+                      The <code>Value</code> will be compared to the selected metadata or to the header of a table. If you select <code>Regex</code>, you can enter a regular expression as value.
+                    </li>
+                    <li>If you provide a line number, only this line of the header will be used. If line number is ommited, the whole header is compared (or searched with the Regex).
+                    </li>
+                    <li>
+                      If groups are used in the regular expression (e.g. <code>Key: (.*?)</code>) only the first group will be extracted as metadata.
+                    </li>
+                    <li>
+                      If you enter an <code>Output key</code> the matched value will be added to the output tables. If you set an <code>Output table</code> explicitely, it will only be added to this table, otherwise it will be added to all output tables.
+                    </li>
+                    <li>
+                      The <code>Output layer</code> input is used for additional processing in the Chemotion ELN.
+                    </li>
+                  </ul>
+                </small>
               </div>
             </div>
 

--- a/src/js/components/admin/create/ProfileCreate.js
+++ b/src/js/components/admin/create/ProfileCreate.js
@@ -11,18 +11,34 @@ class ProfileCreate extends Component {
     super(props)
   }
 
-  renderTableHeader(table) {
+  renderMetadata(metadata) {
     return (
-      <div>
-        Header
-        <pre>
+      <div className="">
+        <dl className="row">
           {
-            table.header.map((line, index) => {
-              return <code key={index}>{line}</code>
+            Object.keys(metadata).map((key, index) => {
+              return (
+                <React.Fragment key={index}>
+                  <dt className="col-sm-3">{key}:</dt>
+                  <dd className="col-sm-9 mb-0">{metadata[key]}</dd>
+                </React.Fragment>
+              )
             })
           }
-        </pre>
+        </dl>
       </div>
+    )
+  }
+
+  renderHeader(header) {
+    return (
+      <pre>
+        {
+          header.map((line, index) => {
+            return <code key={index}>{line}</code>
+          })
+        }
+      </pre>
     )
   }
 
@@ -53,48 +69,64 @@ class ProfileCreate extends Component {
       <div className="row">
         <div className="col-md-7 scroll">
           <div className="mb-5">
-            <h4>Metadata</h4>
-            <div className="pt-3 pb-3 mb-3 border-top border-bottom">
-              {Object.keys(tableData.metadata).map((entry, index) => {
-                return <div key={index}>{entry}: {tableData.metadata[entry]}</div>
-              })}
-            </div>
+            <hr />
+            <h4>Input file metadata</h4>
+            {Object.keys(tableData.metadata).length > 0 && this.renderMetadata(tableData.metadata)}
+            <hr />
 
-            <h4>Tables</h4>
             <ul className="nav nav-tabs" id="Tabs" role="tablist">
               {tableData.data.map((table, index) => {
                 return (
                   <li key={index} className="nav-item" role="presentation">
                     <a className={`nav-link ${index == 0 ? "active" : ""}`} id="table-data-tab" href={'#table-data-' + index}
-                      data-toggle="tab" role="tab" aria-controls="profile" aria-selected="false">Table #{index}</a>
+                      data-toggle="tab" role="tab" aria-controls="profile" aria-selected="false">Input table #{index}</a>
                   </li>
                 )
               })}
             </ul>
 
-            <div className="tab-content border-bottom pt-3" id="Tabs">
-              {tableData.data.map((table, index) => {
-                return (
-                  <div key={index} className={`tab-pane fade ${index == 0 ? "active show" : ""}`} id={'table-data-' + index}
-                    role="tabpanel" aria-labelledby="table-data-tab">
+            <div className="tab-content pt-3" id="Tabs">
+              {
+                tableData.data.map((table, index) => {
+                  return (
+                    <div key={index} className={`tab-pane fade ${index == 0 ? "active show" : ""}`} id={'table-data-' + index}
+                      role="tabpanel" aria-labelledby="table-data-tab">
 
-                    {table.header.length > 0 && this.renderTableHeader(table)}
-
-                    {table.rows.length > 0 &&
-                      <div>
-                        <div className="form-group form-check">
-                          <input type="checkbox" checked={table.firstRowIsHeader || false}
-                            onChange={e => toggleFirstRowIsHeader(index)}
-                            className="form-check-input" id="first_row_is_header" />
-                          <label className="form-check-label" htmlFor="first_row_is_header">First row are column names</label>
+                      {
+                        table.metadata !== undefined && Object.keys(table.metadata).length > 0 &&
+                        <div>
+                          <h4>Input table metadata</h4>
+                          {this.renderMetadata(table.metadata)}
+                          <hr />
                         </div>
+                      }
+                      {
+                        table.header !== undefined && table.header.length > 0 &&
+                        <div>
+                          <h4>Input table header</h4>
+                          {this.renderHeader(table.header)}
+                          <hr />
+                        </div>
+                      }
+                      {
+                        table.rows !== undefined && table.rows !== undefined && table.rows.length > 0 &&
+                        <div>
+                          <h4>Input table data</h4>
 
-                        {this.renderDataGrid(table)}
-                      </div>
-                    }
-                  </div>
-                )
-              })
+                          {this.renderDataGrid(table)}
+
+                          <div className="form-group form-check mt-3">
+                            <input type="checkbox" checked={table.firstRowIsHeader || false}
+                              onChange={e => toggleFirstRowIsHeader(index)}
+                              className="form-check-input" id="first_row_is_header" />
+                            <label className="form-check-label" htmlFor="first_row_is_header">First row are column names</label>
+                          </div>
+                          <hr />
+                        </div>
+                      }
+                    </div>
+                  )
+                })
               }
             </div>
           </div>
@@ -128,7 +160,7 @@ class ProfileCreate extends Component {
                       <div className="card-header">
                         <div className="form-row">
                           <div className="col-lg-10">
-                            Table #{index}
+                            Output table #{index}
                           </div>
                           <div className="col-lg-2">
                             <button type="button" className="btn btn-danger btn-sm btn-block float-right" onClick={removeTable}>Remove</button>

--- a/src/js/components/admin/edit/TableColumn.js
+++ b/src/js/components/admin/edit/TableColumn.js
@@ -12,12 +12,17 @@ class TableColumn extends Component {
     const { table, label, columnKey, operationsKey, updateTable,
             addOperation, updateOperation, removeOperation } = this.props
 
-    const getValue = (column, key) => {
+    const getIndex = (column, key) => {
       if (column !== undefined && typeof column[key] == 'number' && !isNaN(column[key])) {
         return column[key]
       } else {
         return null
       }
+    }
+
+    const getValue = (column, key) => {
+      const index = getIndex(column, key)
+      return index === null ? '' : index
     }
 
     return (
@@ -30,9 +35,9 @@ class TableColumn extends Component {
               className="form-control form-control-sm"
               onChange={event => updateTable(columnKey, {
                 tableIndex: parseInt(event.target.value),
-                columnIndex: getValue(table[columnKey], 'columnIndex')
+                columnIndex: getIndex(table[columnKey], 'columnIndex')
               })}
-              value={getValue(table[columnKey], 'tableIndex') || ''}
+              value={getValue(table[columnKey], 'tableIndex')}
             />
             <small>Table Index</small>
           </div>
@@ -41,10 +46,10 @@ class TableColumn extends Component {
               type="number"
               className="form-control form-control-sm"
               onChange={event => updateTable(columnKey, {
-                tableIndex: getValue(table[columnKey], 'tableIndex'),
+                tableIndex: getIndex(table[columnKey], 'tableIndex'),
                 columnIndex: parseInt(event.target.value)
               })}
-              value={getValue(table[columnKey], 'columnIndex') || ''}
+              value={getValue(table[columnKey], 'columnIndex')}
             />
             <small>Column Index</small>
           </div>
@@ -66,9 +71,9 @@ class TableColumn extends Component {
                         className="form-control form-control-sm"
                         onChange={event => updateOperation(operationsKey, index, 'column', {
                           tableIndex: parseInt(event.target.value),
-                          columnIndex: getValue(operation.column, 'columnIndex')
+                          columnIndex: getIndex(operation.column, 'columnIndex')
                         })}
-                        value={getValue(operation.column, 'tableIndex') || ''}
+                        value={getValue(operation.column, 'tableIndex')}
                       />
                       <small>Table Index</small>
                     </div>
@@ -77,10 +82,10 @@ class TableColumn extends Component {
                         type="number"
                         className="form-control form-control-sm"
                         onChange={event => updateOperation(operationsKey, index, 'column', {
-                          tableIndex: getValue(operation.column, 'tableIndex'),
+                          tableIndex: getIndex(operation.column, 'tableIndex'),
                           columnIndex: parseInt(event.target.value)
                         })}
-                        value={getValue(operation.column, 'columnIndex') || ''}
+                        value={getValue(operation.column, 'columnIndex')}
                       />
                       <small>Column Index</small>
                     </div>


### PR DESCRIPTION
This PR refactors the client to work with the updated version of https://github.com/ComPlat/chemotion-converter-app:
* The there are now 3 identifiers (`fileMetadata`, `tableMetadata`, `tableHeader`), Idnetifier components are reworked.
* New `table.metadata` is added to the "input side".
* Distinction between input tables and output tables is made clearer.
* Help for identifiers is improved.
* *The `EditApp` is updated accordingly (todo).*