### PR TITLE
Add table identifiers to store FIRSTX, LASTX and DELTAX for XYData

### DIFF
--- a/src/js/components/admin/form/TableForm.js
+++ b/src/js/components/admin/form/TableForm.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 
 import HeaderInput from './table/HeaderInput'
 import TableColumn from './TableColumn'
+import TableIdentifier from './TableIdentifier'
+
 
 class TableForm extends Component {
 
@@ -11,12 +13,15 @@ class TableForm extends Component {
   }
 
   render() {
-    const { table, inputColumns, options, updateTable, updateHeader, addOperation, updateOperation, removeOperation } = this.props
+    const { table, inputTables, inputColumns, options,
+            updateTable, updateHeader,
+            addOperation, updateOperation, removeOperation,
+            fileMetadataOptions, tableMetadataOptions } = this.props
 
     return (
       <div>
-        <div>
-          <label>Table header</label>
+        <div className="mb-10">
+          <strong>Table header</strong>
         </div>
 
         {
@@ -25,13 +30,32 @@ class TableForm extends Component {
           ))
         }
 
-        <div>
-          <label>Table columns</label>
+        <div className="mb-10">
+          <strong>Table columns</strong>
         </div>
+        {
+          (table.header['DATA CLASS'] == 'XYDATA') &&
+          <div>
+            <div className="mb-10">
+              Which metadata should be used for the x-values?
+            </div>
+            {
+              ['FIRSTX', 'LASTX', 'DELTAX'].map((headerKey, index) => (
+                <TableIdentifier key={index} index={index + 1000} headerKey={headerKey} table={table}
+                                 inputTables={inputTables} updateHeader={updateHeader}
+                                 fileMetadataOptions={fileMetadataOptions}
+                                 tableMetadataOptions={tableMetadataOptions} />
+              ))
+            }
+          </div>
+        }
+        {
+          (table.header['DATA CLASS'] != 'XYDATA') &&
+          <TableColumn table={table.table} label="Which column should be used as x-values?"
+                       columnKey="xColumn" operationsKey="xOperations" inputColumns={inputColumns} updateTable={updateTable}
+                       addOperation={addOperation} updateOperation={updateOperation} removeOperation={removeOperation}/>
+        }
 
-        <TableColumn table={table.table} label="Which column should be used as x-values?"
-                     columnKey="xColumn" operationsKey="xOperations" inputColumns={inputColumns} updateTable={updateTable}
-                     addOperation={addOperation} updateOperation={updateOperation} removeOperation={removeOperation}/>
         <TableColumn table={table.table} label="Which column should be used as y-values?"
                      columnKey="yColumn" operationsKey="yOperations" inputColumns={inputColumns} updateTable={updateTable}
                      addOperation={addOperation} updateOperation={updateOperation} removeOperation={removeOperation}/>
@@ -45,13 +69,16 @@ class TableForm extends Component {
 
 TableForm.propTypes = {
   table: PropTypes.object,
+  inputTables: PropTypes.array,
   inputColumns: PropTypes.array,
   options: PropTypes.object,
   updateTable: PropTypes.func,
   updateHeader: PropTypes.func,
   addOperation: PropTypes.func,
   updateOperation: PropTypes.func,
-  removeOperation: PropTypes.func
+  removeOperation: PropTypes.func,
+  fileMetadataOptions: PropTypes.array,
+  tableMetadataOptions: PropTypes.array
 }
 
 export default TableForm

--- a/src/js/components/admin/form/TableIdentifier.js
+++ b/src/js/components/admin/form/TableIdentifier.js
@@ -1,0 +1,61 @@
+import React, { Component } from "react"
+import PropTypes from 'prop-types';
+
+import TypeSelect from './identifier/TypeSelect'
+import IdentifierInput from './IdentifierInput'
+
+
+class TableIdentifier extends Component {
+
+  constructor(props) {
+    super(props)
+
+    this.updateTableIdentifier = this.updateTableIdentifier.bind(this)
+  }
+
+  updateTableIdentifier(identifierIndex, data) {
+    const { headerKey, table, updateHeader } = this.props
+    const headerKeyIdentifier = Object.assign({}, table.header[headerKey], data)
+
+    updateHeader(headerKey, headerKeyIdentifier)
+  }
+
+  render() {
+    const { index, headerKey, table, inputTables,
+            fileMetadataOptions, tableMetadataOptions } = this.props
+
+    return (
+      <div>
+        <div className="row">
+          <div className="col-md-2 mb-10">
+            <p className="form-control-static">{headerKey}</p>
+          </div>
+          <div className="col-md-10 mb-10">
+            <TypeSelect index={index} identifier={table.header[headerKey]}
+                        updateIdentifier={this.updateTableIdentifier} />
+          </div>
+        </div>
+        <IdentifierInput
+          index={index}
+          identifier={table.header[headerKey]}
+          inputTables={inputTables}
+          fileMetadataOptions={fileMetadataOptions}
+          tableMetadataOptions={tableMetadataOptions}
+          updateIdentifier={this.updateTableIdentifier}
+        />
+      </div>
+    )
+  }
+}
+
+TableIdentifier.propTypes = {
+  index: PropTypes.number,
+  headerKey: PropTypes.string,
+  table: PropTypes.object,
+  inputTables: PropTypes.array,
+  updateHeader: PropTypes.func,
+  fileMetadataOptions: PropTypes.array,
+  tableMetadataOptions: PropTypes.array
+}
+
+export default TableIdentifier

--- a/src/js/components/admin/form/identifier/TypeSelect.js
+++ b/src/js/components/admin/form/identifier/TypeSelect.js
@@ -1,0 +1,21 @@
+import React, { Component } from "react"
+import PropTypes from 'prop-types';
+
+const TypeSelect = ({ index, identifier, updateIdentifier }) => {
+  return (
+    <select className="form-control input-sm" value={identifier.type}
+            onChange={(event) => updateIdentifier(index, { type: event.target.value })}>
+      <option value="fileMetadata">Based on file metadata</option>
+      <option value="tableMetadata">Based on table metadata</option>
+      <option value="tableHeader">Based on table headers</option>
+    </select>
+  )
+}
+
+TypeSelect.propTypes = {
+  index: PropTypes.number,
+  identifier: PropTypes.object,
+  updateIdentifier: PropTypes.func
+}
+
+export default TypeSelect


### PR DESCRIPTION
This PR adds a new class of identifiers to be used when `DATA CLASS` `XYData` is used. `FIRSTX`, `LASTX`, and `DELTAX` extract the metadata needed to specifiy the (equally spaced) x axis. To be used with https://github.com/ComPlat/chemotion-converter-app/pull/38.